### PR TITLE
Fix Dockerfile script, bump m8c version, parametrize via envs

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,8 @@
 FROM --platform=linux/arm64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LINUX_KERNEL_VERSION=4.9.170
+ENV M8C_VERSION=1.7.10
 
 # Update and install required packages
 RUN apt-get update && apt-get install -y \
@@ -27,14 +29,14 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /build
 
 # Download and extract Linux kernel
-RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.9.170.tar.gz && \
-    tar -xzf linux-4.9.170.tar.gz && \
-    rm linux-4.9.170.tar.gz
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${LINUX_KERNEL_VERSION}.tar.gz && \
+    tar -xzf linux-${LINUX_KERNEL_VERSION}.tar.gz && \
+    rm linux-${LINUX_KERNEL_VERSION}.tar.gz
 
 # Clone m8c directly
 RUN git clone https://github.com/laamaa/m8c.git && \
     cd m8c && \
-    git checkout v1.7.8
+    git checkout v${M8C_VERSION}
 
 # Download Knulli Linux config file
 RUN wget -O linux-sunxi64-legacy.config https://raw.githubusercontent.com/knulli-cfw/distribution/knulli-main/board/batocera/allwinner/h700/linux-sunxi64-legacy.config

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LINUX_KERNEL_VERSION=4.9.170
+ENV M8C_VERSION=1.7.10
 
 # Update GPG keys and install required packages
 RUN apt-get clean && \
@@ -26,15 +28,15 @@ RUN apt-get clean && \
 WORKDIR /build
 
 # Download and extract Linux kernel
-RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.9.170.tar.gz && \
-    tar -xzf linux-4.9.170.tar.gz && \
-    rm linux-4.9.170.tar.gz
+RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${LINUX_KERNEL_VERSION}.tar.gz && \
+    tar -xzf linux-${LINUX_KERNEL_VERSION}.tar.gz && \
+    rm linux-${LINUX_KERNEL_VERSION}.tar.gz
 
 # Download and prepare m8c
-RUN wget https://github.com/laamaa/m8c/archive/refs/tags/v1.7.8.tar.gz \
-    && tar -xzvf v1.7.8.tar.gz \
-    && mv m8c-1.7.8 m8c \
-    && rm v1.7.8.tar.gz
+RUN wget https://github.com/laamaa/m8c/archive/refs/tags/v${M8C_VERSION}.tar.gz \
+    && tar -xzvf v${M8C_VERSION}.tar.gz \
+    && mv m8c-${M8C_VERSION} m8c \
+    && rm v${M8C_VERSION}.tar.gz
 
 # Download Knulli Linux config file
 RUN wget -O linux-sunxi64-legacy.config https://raw.githubusercontent.com/knulli-cfw/distribution/knulli-main/board/batocera/allwinner/h700/linux-sunxi64-legacy.config
@@ -44,62 +46,7 @@ RUN wget -O aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz https://github.com/
     && tar -xzvf aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz \
     && rm aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz
 
-COPY build_script.sh /build/
-RUN chmod +x /build/build_script.sh && dos2unix /build/build_script.sh
-
-# Ensure the output directory exists
-RUN mkdir -p /build/compiled/m8c
-
-CMD ["/bin/bash", "/build/build_script.sh"]
-
-# Dockerfile.arm64
-FROM --platform=linux/arm64 ubuntu:22.04
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Update GPG keys and install required packages
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get update && \
-    apt-get install -y gnupg && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 871920D1991BC93C && \
-    apt-get update && \
-    apt-get install -y \
-    wget \
-    tar \
-    make \
-    gcc \
-    sed \
-    crossbuild-essential-arm64 \
-    ca-certificates \
-    bc \
-    libssl-dev \
-    pkg-config \
-    dos2unix \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-
-# Download and extract Linux kernel
-RUN wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.9.170.tar.gz && \
-    tar -xzf linux-4.9.170.tar.gz && \
-    rm linux-4.9.170.tar.gz
-
-# Download and prepare m8c
-RUN wget https://github.com/laamaa/m8c/archive/refs/tags/v1.7.8.tar.gz \
-    && tar -xzvf v1.7.8.tar.gz \
-    && mv m8c-1.7.8 m8c \
-    && rm v1.7.8.tar.gz
-
-# Download Knulli Linux config file
-RUN wget -O linux-sunxi64-legacy.config https://raw.githubusercontent.com/knulli-cfw/distribution/knulli-main/board/batocera/allwinner/h700/linux-sunxi64-legacy.config
-
-# Download and extract Knulli ARM64 toolchain with retry
-RUN wget -O aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz https://github.com/knulli-cfw/toolchains/releases/download/rg35xx-plush-sdk-20240421/aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz \
-    && tar -xzvf aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz \
-    && rm aarch64-buildroot-linux-gnu_sdk-buildroot.tar.gz
-
-COPY build_script.sh /build/
+COPY build_script.x86_64.sh /build/build_script.sh
 RUN chmod +x /build/build_script.sh && dos2unix /build/build_script.sh
 
 # Ensure the output directory exists

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The idea behind this is to provide a platform that makes it relatively easy for 
 This version builds using:
 - Linux kernel `v4.9.170`
 - Knulli RG35XX Plus/H/SP/2024 toolchain `rg35xx-plush-sdk-20240421/aarch64-buildroot-linux-gnu_sdk-buildroot`
-- m8c `v1.7.8`
+- m8c `v1.7.10`
 
 ## Usage
 

--- a/build_script.arm64.sh
+++ b/build_script.arm64.sh
@@ -18,7 +18,7 @@ fi
 
 # Build kernel modules
 echo "Building kernel modules..."
-cd /build/linux-4.9.170
+cd /build/linux-$LINUX_KERNEL_VERSION
 
 echo "Configuring kernel..."
 cp /build/linux-sunxi64-legacy.config .config
@@ -39,7 +39,7 @@ echo "Collecting files..."
 
 # Copy kernel modules
 for module in cdc-acm.ko snd-hwdep.ko snd-usbmidi-lib.ko snd-usb-audio.ko; do
-  find /build/linux-4.9.170 -name "$module" -exec cp -v {} /build/compiled/m8c \; || echo "Warning: $module not found"
+  find /build/linux-$LINUX_KERNEL_VERSION -name "$module" -exec cp -v {} /build/compiled/m8c \; || echo "Warning: $module not found"
 done
 
 # Copy m8c executable
@@ -52,7 +52,7 @@ else
 fi
 
 # Create m8c.sh script
-cat <<'EOF' >/build/compiled/m8c.sh
+sed "s/\$LINUX_KERNEL_VERSION/$LINUX_KERNEL_VERSION/" <<'EOF' >/build/compiled/m8c.sh
 #!/bin/sh
 
 export HOME=$(dirname $(realpath $0))/m8c
@@ -61,7 +61,7 @@ cd $HOME
 # Ensure m8c is executable
 chmod +x ./m8c
 
-cp *.ko /lib/modules/4.9.170
+cp *.ko /lib/modules/$LINUX_KERNEL_VERSION
 depmod
 modprobe -a cdc-acm snd-hwdep snd-usbmidi-lib snd-usb-audio
 

--- a/build_script.x86_64.sh
+++ b/build_script.x86_64.sh
@@ -28,7 +28,7 @@ fi
 
 # Build kernel modules
 echo "Building kernel modules..."
-cd /build/linux-4.9.170
+cd /build/linux-$LINUX_KERNEL_VERSION
 
 echo "Configuring kernel..."
 cp /build/linux-sunxi64-legacy.config .config
@@ -49,7 +49,7 @@ echo "Collecting files..."
 
 # Copy kernel modules
 for module in cdc-acm.ko snd-hwdep.ko snd-usbmidi-lib.ko snd-usb-audio.ko; do
-  find /build/linux-4.9.170 -name "$module" -exec cp -v {} /build/compiled/m8c \; || echo "Warning: $module not found"
+  find /build/linux-$LINUX_KERNEL_VERSION -name "$module" -exec cp -v {} /build/compiled/m8c \; || echo "Warning: $module not found"
 done
 
 # Copy m8c executable
@@ -62,7 +62,7 @@ else
 fi
 
 # Create m8c.sh script
-cat <<'EOF' >/build/compiled/m8c.sh
+sed "s/\$LINUX_KERNEL_VERSION/$LINUX_KERNEL_VERSION/" <<'EOF' >/build/compiled/m8c.sh
 #!/bin/sh
 
 export HOME=$(dirname $(realpath $0))/m8c
@@ -71,7 +71,7 @@ cd $HOME
 # Ensure m8c is executable
 chmod +x ./m8c
 
-cp *.ko /lib/modules/4.9.170
+cp *.ko /lib/modules/$LINUX_KERNEL_VERSION
 depmod
 modprobe -a cdc-acm snd-hwdep snd-usbmidi-lib snd-usb-audio
 


### PR DESCRIPTION
- Fixed `Dockerfile.x86_64` (it had some code from `Dockerfile.arm64`)
- Bumped M8C library version to stay up to date
- Parametrized versions via envs for better maintainability